### PR TITLE
Install from .deb instead of from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,7 @@ RUN echo export SGE_CELL=default >> /etc/bashrc
 RUN ln -s $SGE_ROOT/$SGE_CELL/common/settings.sh /etc/profile.d/sge_settings.sh
 
 # install SGE
-RUN useradd -r -m -U -d /home/sgeuser -s /bin/bash -c "Docker SGE user" sgeuser
-RUN usermod -a -G sudo sgeuser
+RUN useradd -r -m -U -G sudo -d /home/sgeuser -s /bin/bash -c "Docker SGE user" sgeuser
 WORKDIR $SGE_ROOT
 RUN ./inst_sge -m -x -s -auto ~/sge_auto_install.conf \
 && /etc/my_init.d/01_docker_sge_init.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@
 
 FROM phusion/baseimage:0.9.19
 
-# maintained by me
-MAINTAINER Robert Syme <rbosyme@gmail.com>
-
 # expose ports
 EXPOSE 6444
 EXPOSE 6445

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Cloned and updated version of the docker-sge container from gawbul
 
-FROM phusion/baseimage:0.9.15
+FROM phusion/baseimage:0.9.19
 
 # maintained by me
 MAINTAINER Robert Syme <rbosyme@gmail.com>
@@ -18,60 +18,28 @@ ENV HOME /root
 # regenerate host ssh keys
 RUN /etc/my_init.d/00_regen_ssh_host_keys.sh
 
-# add pin priority to some graphical packages to stop them installing and borking the build
-RUN echo "Package: xserver-xorg*\nPin: release *\nPin-Priority: -1" >> /etc/apt/preferences
-RUN echo "Package: unity*\nPin: release *\nPin-Priority: -1" >> /etc/apt/preferences
-RUN echo "Package: gnome*\nPin: release *\nPin-Priority: -1" >> /etc/apt/preferences
+# install required software
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y \
+    && apt-get install -y sudo bsd-mailx tcsh db5.3-util libhwloc5 libmunge2 libxm4 libjemalloc1 xterm openjdk-8-jre-headless \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # turn off password requirement for sudo groups users
 RUN sed -i "s/^\%sudo\tALL=(ALL:ALL)\sALL/%sudo ALL=(ALL) NOPASSWD:ALL/" /etc/sudoers
 
-# install required software as per README.BUILD
-RUN apt-get update -y
-RUN apt-get install -y wget darcs git mercurial tcsh build-essential automake autoconf openssl libssl-dev munge libmunge2 libmunge-dev libjemalloc1 libjemalloc-dev db5.3-util libdb-dev libncurses5 libncurses5-dev libpam0g libpam0g-dev libpacklib-lesstif1-dev libmotif-dev libxmu-dev libxpm-dev hwloc libhwloc-dev openjdk-7-jre openjdk-7-jdk ant ant-optional javacc junit libswing-layout-java libxft2 libxft-dev libreadline-dev man gawk
+# Download and install debian packages from Son of Grid Engine
+ADD https://arc.liv.ac.uk/downloads/SGE/releases/8.1.9/sge-common_8.1.9_all.deb /root/
+ADD https://arc.liv.ac.uk/downloads/SGE/releases/8.1.9/sge-doc_8.1.9_all.deb /root/
+ADD https://arc.liv.ac.uk/downloads/SGE/releases/8.1.9/sge_8.1.9_amd64.deb /root/
+RUN dpkg -i /root/*.deb
 
 # add files to container from local directory
-ADD izpack_auto_install.xml /root/izpack_auto_install.xml
 ADD sge_auto_install.conf /root/sge_auto_install.conf
 ADD docker_sge_init.sh /etc/my_init.d/01_docker_sge_init.sh
 ADD sge_exec_host.conf /root/sge_hostgrp.conf
 ADD sge_exec_host.conf /root/sge_exec_host.conf
 ADD sge_queue.conf /root/sge_queue.conf
 RUN chmod ug+x /etc/my_init.d/01_docker_sge_init.sh
-
-# change to home directory
-WORKDIR $HOME
-
-# retrieve required files
-RUN wget -c http://download.jboss.org/jbosstools/updates/requirements/izpack/4.3.5/IzPack-install-4.3.5.jar
-RUN wget -c http://mirror.global-layer.com/ubuntu/pool/main/libz/libzip/libzip1_0.9-3_amd64.deb
-RUN wget -c http://mirror.global-layer.com/ubuntu/pool/main/libz/libzip/libzip-dev_0.9-3_amd64.deb
-RUN wget -c http://archive.cloudera.com/one-click-install/lucid/cdh3-repository_1.0_all.deb
-
-# install izpack
-RUN java -jar IzPack-install-4.3.5.jar ~/izpack_auto_install.xml
-ENV PATH /usr/local/izpack/bin:$PATH
-RUN echo export PATH=/usr/local/izpack/bin:$PATH >> /etc/bashrc
-
-# install hadoop
-RUN dpkg -i libzip1_0.9-3_amd64.deb
-RUN dpkg -i libzip-dev_0.9-3_amd64.deb
-RUN dpkg -i cdh3-repository_1.0_all.deb
-RUN apt-get update && apt-get -y install hadoop-0.20 hadoop-0.20-native
-
-# clone the SGE git repository
-# git repo takes forever
-# issues with the hg repository currently
-# probems with darcs too that docker doesn't like
-#RUN hg clone http://arc.liv.ac.uk/repos/hg/sge
-#RUN darcs get --lazy --set-scripts-executable http://arc.liv.ac.uk/repos/darcs/sge
-#RUN git clone http://arc.liv.ac.uk/repos/git/sge
-# download source tarball instead
-RUN wget -c https://arc.liv.ac.uk/downloads/SGE/releases/8.1.8/sge-8.1.8.tar.gz
-RUN tar -zxvf sge-8.1.8.tar.gz
-
-# change working directory
-WORKDIR $HOME/sge-8.1.8/source
 
 # setup SGE env
 ENV SGE_ROOT /opt/sge
@@ -81,17 +49,14 @@ RUN echo export SGE_CELL=default >> /etc/bashrc
 RUN ln -s $SGE_ROOT/$SGE_CELL/common/settings.sh /etc/profile.d/sge_settings.sh
 
 # install SGE
-RUN mkdir /opt/sge
-RUN useradd -r -m -U -d /home/sgeadmin -s /bin/bash -c "Docker SGE Admin" sgeadmin
-RUN usermod -a -G sudo sgeadmin
-RUN sh scripts/bootstrap.sh && ./aimk && ./aimk -man
-RUN echo Y | ./scripts/distinst -local -allall -libs -noexit
+RUN useradd -r -m -U -d /home/sgeuser -s /bin/bash -c "Docker SGE user" sgeuser
+RUN usermod -a -G sudo sgeuser
 WORKDIR $SGE_ROOT
 RUN ./inst_sge -m -x -s -auto ~/sge_auto_install.conf \
 && /etc/my_init.d/01_docker_sge_init.sh \
 && sed -i "s/HOSTNAME/`hostname`/" $HOME/sge_exec_host.conf \
 && sed -i "s/HOSTNAME/`hostname`/" $HOME/sge_hostgrp.conf \
-&& /opt/sge/bin/lx-amd64/qconf -au sgeadmin arusers \
+&& /opt/sge/bin/lx-amd64/qconf -au sgeuser arusers \
 && /opt/sge/bin/lx-amd64/qconf -Me $HOME/sge_exec_host.conf \
 && /opt/sge/bin/lx-amd64/qconf -Aq $HOME/sge_queue.conf
 
@@ -103,10 +68,6 @@ WORKDIR $HOME
 
 # clean up
 RUN rm *.deb
-RUN rm *.jar
-RUN rm *.tar.gz
-RUN rm -rf sge-8.1.8
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # start my_init on execution and pass bash to runit
 ENTRYPOINT ["/sbin/my_init", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN ln -s $SGE_ROOT/$SGE_CELL/common/settings.sh /etc/profile.d/sge_settings.sh
 RUN useradd -r -m -U -G sudo -d /home/sgeuser -s /bin/bash -c "Docker SGE user" sgeuser
 WORKDIR $SGE_ROOT
 RUN ./inst_sge -m -x -s -auto ~/sge_auto_install.conf \
+&& sleep 10 \
 && /etc/init.d/sgemaster.docker-sge restart \
 && /etc/init.d/sgeexecd.docker-sge restart \
 && sed -i "s/HOSTNAME/`hostname`/" $HOME/sge_exec_host.conf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,6 @@ EXPOSE 6444
 EXPOSE 6445
 EXPOSE 6446
 
-# run everything as root to start with
-USER root
-
 # set environment variables
 ENV HOME /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN ln -s $SGE_ROOT/$SGE_CELL/common/settings.sh /etc/profile.d/sge_settings.sh
 RUN useradd -r -m -U -G sudo -d /home/sgeuser -s /bin/bash -c "Docker SGE user" sgeuser
 WORKDIR $SGE_ROOT
 RUN ./inst_sge -m -x -s -auto ~/sge_auto_install.conf \
-&& /etc/my_init.d/01_docker_sge_init.sh \
+&& /etc/init.d/sgemaster.docker-sge restart \
+&& /etc/init.d/sgeexecd.docker-sge restart \
 && sed -i "s/HOSTNAME/`hostname`/" $HOME/sge_exec_host.conf \
 && sed -i "s/HOSTNAME/`hostname`/" $HOME/sge_hostgrp.conf \
 && /opt/sge/bin/lx-amd64/qconf -au sgeuser arusers \

--- a/sge_auto_install.conf
+++ b/sge_auto_install.conf
@@ -64,7 +64,7 @@ SGE_JMX_SSL_KEYSTORE_PW="/keystore"
 # the system, Grid Engine will try to find a correct value.  If it
 # cannot do so, the value is set to "jvmlib_missing" and the JMX
 # thread will be configured but will fail to start
-SGE_JVM_LIB_PATH="/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server/libjvm.so"
+SGE_JVM_LIB_PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so"
 
 # SGE_ADDITIONAL_JVM_ARGS is used by qmaster's jvm thread
 # jvm specific arguments as -verbose:jni etc.


### PR DESCRIPTION
Hi Rob,

I was looking for a way of reducing the disk usage of the image by reducing the number of layers / the size of the layers. Accidentally, I've found that https://arc.liv.ac.uk/ has debian packages of SGE and I thought I would give them a try.

Find below a few commits that switch from building from source to installing these packages. The resulting image is ~650MB instead of 1.55GB, which is a huge gain ! (and it's also faster to build).
I've made some tests with the SGE backend of our workflow manager, and it is working well. I don't know if you have ways of testing the installation any further.

A major chance is that the _sgeadmin_ user is now created by the .deb packages and we can't log in with it (its shell is `/bin/false`), so I've created another user _sgeuser_ the same way as you were doing. I use _sgeuser_ in all my tests.

Let me know what you think. I understand this is a more controversial change than my previous pull-request. I would have liked to first open an issue to discuss this but that's disabled on this repo (no worries, we've also disabled them on our repos :D)

Regards,
Matthieu